### PR TITLE
Fix behavior against R# cache contract

### DIFF
--- a/src/AgentMulder.ReSharper.Plugin/Components/RegisteredTypeCollector.cs
+++ b/src/AgentMulder.ReSharper.Plugin/Components/RegisteredTypeCollector.cs
@@ -188,13 +188,14 @@ namespace AgentMulder.ReSharper.Plugin.Components
                 return;
             }
 
-            if (!patternManager.GetAllRegistrations().Any())
-            {
-                return;
-            }
-
             lock (lockObject)
             {
+                if (!patternManager.GetAllRegistrations().Any())
+                {
+                    dirtyFiles.Clear();
+                    return;
+                }
+            
                 if (HasDirtyFiles)
                 {
                     foreach (var psiSourceFile in dirtyFiles.ToList()) // ToList to prevent InvalidOperation while enumerating


### PR DESCRIPTION
Fixes repeated silent exceptions when R# requests cache updates. It seems to be also fixing some issues with intellisense that might occur after installing Mulder.