### PR TITLE
Update for ReSharper 2019.2

### DIFF
--- a/src/AgentMulder.Containers.AspNetCore/AgentMulder.Containers.AspNetCore.csproj
+++ b/src/AgentMulder.Containers.AspNetCore/AgentMulder.Containers.AspNetCore.csproj
@@ -6,7 +6,7 @@
   <Import Project="..\Configuration.props" />
   <Import Project="..\Containers.props" />
   <ItemGroup>
-    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2019.2.0-eap06">
+    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2019.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/AgentMulder.Containers.AspNetCore/AgentMulder.Containers.AspNetCore.csproj
+++ b/src/AgentMulder.Containers.AspNetCore/AgentMulder.Containers.AspNetCore.csproj
@@ -6,7 +6,7 @@
   <Import Project="..\Configuration.props" />
   <Import Project="..\Containers.props" />
   <ItemGroup>
-    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2019.1.1">
+    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2019.2.0-eap06">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/AgentMulder.Containers.Autofac/AgentMulder.Containers.Autofac.csproj
+++ b/src/AgentMulder.Containers.Autofac/AgentMulder.Containers.Autofac.csproj
@@ -6,7 +6,7 @@
   <Import Project="..\Configuration.props" />
   <Import Project="..\Containers.props" />
   <ItemGroup>
-    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2019.2.0-eap06">
+    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2019.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/AgentMulder.Containers.Autofac/AgentMulder.Containers.Autofac.csproj
+++ b/src/AgentMulder.Containers.Autofac/AgentMulder.Containers.Autofac.csproj
@@ -6,7 +6,7 @@
   <Import Project="..\Configuration.props" />
   <Import Project="..\Containers.props" />
   <ItemGroup>
-    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2019.1.1">
+    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2019.2.0-eap06">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/AgentMulder.Containers.CastleWindsor/AgentMulder.Containers.CastleWindsor.csproj
+++ b/src/AgentMulder.Containers.CastleWindsor/AgentMulder.Containers.CastleWindsor.csproj
@@ -6,7 +6,7 @@
   <Import Project="..\Configuration.props" />
   <Import Project="..\Containers.props" />
   <ItemGroup>
-    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2019.2.0-eap06">
+    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2019.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/AgentMulder.Containers.CastleWindsor/AgentMulder.Containers.CastleWindsor.csproj
+++ b/src/AgentMulder.Containers.CastleWindsor/AgentMulder.Containers.CastleWindsor.csproj
@@ -6,7 +6,7 @@
   <Import Project="..\Configuration.props" />
   <Import Project="..\Containers.props" />
   <ItemGroup>
-    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2019.1.1">
+    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2019.2.0-eap06">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/AgentMulder.Containers.Catel/AgentMulder.Containers.Catel.csproj
+++ b/src/AgentMulder.Containers.Catel/AgentMulder.Containers.Catel.csproj
@@ -6,7 +6,7 @@
   <Import Project="..\Configuration.props" />
   <Import Project="..\Containers.props" />
   <ItemGroup>
-    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2019.2.0-eap06">
+    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2019.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/AgentMulder.Containers.Catel/AgentMulder.Containers.Catel.csproj
+++ b/src/AgentMulder.Containers.Catel/AgentMulder.Containers.Catel.csproj
@@ -6,7 +6,7 @@
   <Import Project="..\Configuration.props" />
   <Import Project="..\Containers.props" />
   <ItemGroup>
-    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2019.1.1">
+    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2019.2.0-eap06">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/AgentMulder.Containers.LightInject/AgentMulder.Containers.LightInject.csproj
+++ b/src/AgentMulder.Containers.LightInject/AgentMulder.Containers.LightInject.csproj
@@ -6,7 +6,7 @@
   <Import Project="..\Configuration.props" />
   <Import Project="..\Containers.props" />
   <ItemGroup>
-    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2019.2.0-eap06">
+    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2019.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/AgentMulder.Containers.LightInject/AgentMulder.Containers.LightInject.csproj
+++ b/src/AgentMulder.Containers.LightInject/AgentMulder.Containers.LightInject.csproj
@@ -6,7 +6,7 @@
   <Import Project="..\Configuration.props" />
   <Import Project="..\Containers.props" />
   <ItemGroup>
-    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2019.1.1">
+    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2019.2.0-eap06">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/AgentMulder.Containers.Ninject/AgentMulder.Containers.Ninject.csproj
+++ b/src/AgentMulder.Containers.Ninject/AgentMulder.Containers.Ninject.csproj
@@ -6,7 +6,7 @@
   <Import Project="..\Configuration.props" />
   <Import Project="..\Containers.props" />
   <ItemGroup>
-    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2019.2.0-eap06">
+    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2019.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/AgentMulder.Containers.Ninject/AgentMulder.Containers.Ninject.csproj
+++ b/src/AgentMulder.Containers.Ninject/AgentMulder.Containers.Ninject.csproj
@@ -6,7 +6,7 @@
   <Import Project="..\Configuration.props" />
   <Import Project="..\Containers.props" />
   <ItemGroup>
-    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2019.1.1">
+    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2019.2.0-eap06">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/AgentMulder.Containers.SimpleInjector/AgentMulder.Containers.SimpleInjector.csproj
+++ b/src/AgentMulder.Containers.SimpleInjector/AgentMulder.Containers.SimpleInjector.csproj
@@ -6,7 +6,7 @@
   <Import Project="..\Configuration.props" />
   <Import Project="..\Containers.props" />
   <ItemGroup>
-    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2019.2.0-eap06">
+    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2019.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/AgentMulder.Containers.SimpleInjector/AgentMulder.Containers.SimpleInjector.csproj
+++ b/src/AgentMulder.Containers.SimpleInjector/AgentMulder.Containers.SimpleInjector.csproj
@@ -6,7 +6,7 @@
   <Import Project="..\Configuration.props" />
   <Import Project="..\Containers.props" />
   <ItemGroup>
-    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2019.1.1">
+    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2019.2.0-eap06">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/AgentMulder.Containers.StructureMap/AgentMulder.Containers.StructureMap.csproj
+++ b/src/AgentMulder.Containers.StructureMap/AgentMulder.Containers.StructureMap.csproj
@@ -6,7 +6,7 @@
   <Import Project="..\Configuration.props" />
   <Import Project="..\Containers.props" />
   <ItemGroup>
-    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2019.2.0-eap06">
+    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2019.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/AgentMulder.Containers.StructureMap/AgentMulder.Containers.StructureMap.csproj
+++ b/src/AgentMulder.Containers.StructureMap/AgentMulder.Containers.StructureMap.csproj
@@ -6,7 +6,7 @@
   <Import Project="..\Configuration.props" />
   <Import Project="..\Containers.props" />
   <ItemGroup>
-    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2019.1.1">
+    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2019.2.0-eap06">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/AgentMulder.Containers.Unity/AgentMulder.Containers.Unity.csproj
+++ b/src/AgentMulder.Containers.Unity/AgentMulder.Containers.Unity.csproj
@@ -6,7 +6,7 @@
   <Import Project="..\Configuration.props" />
   <Import Project="..\Containers.props" />
   <ItemGroup>
-    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2019.2.0-eap06">
+    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2019.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/AgentMulder.Containers.Unity/AgentMulder.Containers.Unity.csproj
+++ b/src/AgentMulder.Containers.Unity/AgentMulder.Containers.Unity.csproj
@@ -6,7 +6,7 @@
   <Import Project="..\Configuration.props" />
   <Import Project="..\Containers.props" />
   <ItemGroup>
-    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2019.1.1">
+    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2019.2.0-eap06">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/AgentMulder.ReSharper.Domain/AgentMulder.ReSharper.Domain.csproj
+++ b/src/AgentMulder.ReSharper.Domain/AgentMulder.ReSharper.Domain.csproj
@@ -6,7 +6,7 @@
   <Import Project="..\Configuration.props" />
   <Import Project="..\Main.props" />
   <ItemGroup>
-    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2019.2.0-eap06">
+    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2019.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/AgentMulder.ReSharper.Domain/AgentMulder.ReSharper.Domain.csproj
+++ b/src/AgentMulder.ReSharper.Domain/AgentMulder.ReSharper.Domain.csproj
@@ -6,7 +6,7 @@
   <Import Project="..\Configuration.props" />
   <Import Project="..\Main.props" />
   <ItemGroup>
-    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2019.1.1">
+    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2019.2.0-eap06">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/AgentMulder.ReSharper.Plugin/AgentMulder.ReSharper.Plugin.csproj
+++ b/src/AgentMulder.ReSharper.Plugin/AgentMulder.ReSharper.Plugin.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="EnvDTE80" Version="8.0.3" />
     <PackageReference Include="JetBrains.Annotations" Version="2019.1.1" />
-    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2019.2.0-eap06">
+    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2019.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/AgentMulder.ReSharper.Plugin/AgentMulder.ReSharper.Plugin.csproj
+++ b/src/AgentMulder.ReSharper.Plugin/AgentMulder.ReSharper.Plugin.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="EnvDTE80" Version="8.0.3" />
     <PackageReference Include="JetBrains.Annotations" Version="2019.1.1" />
-    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2019.1.1">
+    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2019.2.0-eap06">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/AgentMulder.ReSharper.Tests/AgentMulder.ReSharper.Tests.csproj
+++ b/src/AgentMulder.ReSharper.Tests/AgentMulder.ReSharper.Tests.csproj
@@ -5,14 +5,15 @@
   </PropertyGroup>
   <Import Project="..\Configuration.props" />
   <ItemGroup>
-    <PackageReference Include="JetBrains.ReSharper.SDK.Tests" Version="2019.1.2">
+    <PackageReference Include="JetBrains.ReSharper.SDK.Tests" Version="2019.2.0-eap06">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="16.1.1" />
-    <PackageReference Include="Microsoft.TestPlatform.TranslationLayer" Version="16.1.1" />
-    <PackageReference Include="NUnit" Version="2.6.4" />
-    <PackageReference Include="NUnitTestAdapter" Version="2.2.0" />
+    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="16.2.0" />
+    <PackageReference Include="Microsoft.TestPlatform.TranslationLayer" Version="16.2.0" />
+    <PackageReference Include="NUnit" Version="3.10.1" />
+    <PackageReference Include="NUnit.ConsoleRunner" Version="3.10.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
     <PackageReference Include="System.Reflection.Metadata" Version="1.6.0" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />

--- a/src/AgentMulder.ReSharper.Tests/AgentMulder.ReSharper.Tests.csproj
+++ b/src/AgentMulder.ReSharper.Tests/AgentMulder.ReSharper.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <Import Project="..\Configuration.props" />
   <ItemGroup>
-    <PackageReference Include="JetBrains.ReSharper.SDK.Tests" Version="2019.2.0-eap06">
+    <PackageReference Include="JetBrains.ReSharper.SDK.Tests" Version="2019.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/AgentMulder.ReSharper.Tests/AgentMulderTestBase.cs
+++ b/src/AgentMulder.ReSharper.Tests/AgentMulderTestBase.cs
@@ -75,20 +75,7 @@ namespace AgentMulder.ReSharper.Tests
             return cSharpFile;
         }
 
-// ReSharper disable MemberCanBePrivate.Global
-        protected IEnumerable TestCases 
-// ReSharper restore MemberCanBePrivate.Global
-        {
-            get
-            {
-                TestUtil.SetHomeDir(GetType().Assembly);
-                var testCasesDirectory = new DirectoryInfo(SolutionItemsBasePath.FullPath);
-                return testCasesDirectory.EnumerateFiles("*.cs").Select(info => new TestCaseData(info.Name)).ToList();
-            }
-        }
-
-        [TestCaseSource("TestCases")]
-        public void Test(string fileName)
+        protected void TestCore(string fileName)
         {
             RunTest(fileName, patternManager =>
             {

--- a/src/AgentMulder.ReSharper.Tests/AspNetCore/RegisterTypesTest.cs
+++ b/src/AgentMulder.ReSharper.Tests/AspNetCore/RegisterTypesTest.cs
@@ -1,10 +1,37 @@
-﻿using AgentMulder.Containers.AspNetCore;
+﻿using System.Collections;
+using System.IO;
+using System.Linq;
+using AgentMulder.Containers.AspNetCore;
+using JetBrains.TestFramework.Utils;
+using NUnit.Framework;
 
 namespace AgentMulder.ReSharper.Tests.AspNetCore
 {
     [TestWithNuGetPackage(Packages = new[] { "Microsoft.Extensions.DependencyInjection/1.1.0" })]
     public class RegisterTypeTests : AgentMulderTestBase<AspNetCoreContainerInfo>
     {
-        protected override string RelativeTestDataPath => "AspNetCore";
+        private const string RelativePath = "AspNetCore";
+
+        protected override string RelativeTestDataPath => RelativePath;
+
+        [Test]
+        [TestCaseSource(nameof(TestCases), methodParams: new object[] { RelativePath })]
+        public void Test(string fileName)
+        {
+            TestCore(fileName);
+        }
+
+        private static IEnumerable TestCases(string relativePath)
+        {
+            TestUtil.SetHomeDir(typeof(AgentMulderTestBase<>).Assembly);
+            var d = new DirectoryInfo(Path.Combine(
+                TestUtil.GetTestDataPathBase(typeof(AgentMulderTestBase<>).Assembly).FullPath, relativePath));
+
+            var testCaseData = d.EnumerateFiles("*.cs")
+                .Select(info => new TestCaseData(info.Name))
+                .ToList();
+
+            return testCaseData;
+        }
     }
 }

--- a/src/AgentMulder.ReSharper.Tests/Autofac/ContainerBuilderTests.cs
+++ b/src/AgentMulder.ReSharper.Tests/Autofac/ContainerBuilderTests.cs
@@ -1,13 +1,37 @@
+using System.Collections;
+using System.IO;
+using System.Linq;
 using AgentMulder.Containers.Autofac;
+using JetBrains.TestFramework.Utils;
+using NUnit.Framework;
 
 namespace AgentMulder.ReSharper.Tests.Autofac
 {
     [TestWithNuGetPackage(Packages = new[] { "Autofac/3.5.2" })]
     public class ContainerBuilderTests : AgentMulderTestBase<AutofacContainerInfo>
     {
-        protected override string RelativeTestDataPath
+        private const string RelativePath = "Autofac";
+
+        protected override string RelativeTestDataPath => RelativePath;
+
+        [Test]
+        [TestCaseSource(nameof(TestCases), methodParams: new object[] { RelativePath })]
+        public void Test(string fileName)
         {
-            get { return @"Autofac"; }
+            TestCore(fileName);
+        }
+
+        private static IEnumerable TestCases(string relativePath)
+        {
+            TestUtil.SetHomeDir(typeof(AgentMulderTestBase<>).Assembly);
+            var d = new DirectoryInfo(Path.Combine(
+                TestUtil.GetTestDataPathBase(typeof(AgentMulderTestBase<>).Assembly).FullPath, relativePath));
+
+            var testCaseData = d.EnumerateFiles("*.cs")
+                .Select(info => new TestCaseData(info.Name))
+                .ToList();
+
+            return testCaseData;
         }
     }
 }

--- a/src/AgentMulder.ReSharper.Tests/Autofac/MvcTests.cs
+++ b/src/AgentMulder.ReSharper.Tests/Autofac/MvcTests.cs
@@ -1,13 +1,37 @@
-﻿using AgentMulder.Containers.Autofac;
+﻿using System.Collections;
+using System.IO;
+using System.Linq;
+using AgentMulder.Containers.Autofac;
+using JetBrains.TestFramework.Utils;
+using NUnit.Framework;
 
 namespace AgentMulder.ReSharper.Tests.Autofac
 {
     [TestWithNuGetPackage(Packages = new[] { "Autofac/3.5.2", "Autofac.Mvc5/3.3.4", "Microsoft.AspNet.WebApi.Core/5.2.3" })]
     public class MvcTests : AgentMulderTestBase<AutofacContainerInfo>
     {
-        protected override string RelativeTestDataPath
+        private const string RelativePath = @"Autofac\Mvc";
+
+        protected override string RelativeTestDataPath => RelativePath;
+
+        [Test]
+        [TestCaseSource(nameof(TestCases), methodParams: new object[] { RelativePath })]
+        public void Test(string fileName)
         {
-            get { return @"Autofac\Mvc"; }
+            TestCore(fileName);
+        }
+
+        private static IEnumerable TestCases(string relativePath)
+        {
+            TestUtil.SetHomeDir(typeof(AgentMulderTestBase<>).Assembly);
+            var d = new DirectoryInfo(Path.Combine(
+                TestUtil.GetTestDataPathBase(typeof(AgentMulderTestBase<>).Assembly).FullPath, relativePath));
+
+            var testCaseData = d.EnumerateFiles("*.cs")
+                .Select(info => new TestCaseData(info.Name))
+                .ToList();
+
+            return testCaseData;
         }
     }
 }

--- a/src/AgentMulder.ReSharper.Tests/Autofac/RegisterAssemblyTypesTests.cs
+++ b/src/AgentMulder.ReSharper.Tests/Autofac/RegisterAssemblyTypesTests.cs
@@ -1,13 +1,37 @@
-﻿using AgentMulder.Containers.Autofac;
+﻿using System.Collections;
+using System.IO;
+using System.Linq;
+using AgentMulder.Containers.Autofac;
+using JetBrains.TestFramework.Utils;
+using NUnit.Framework;
 
 namespace AgentMulder.ReSharper.Tests.Autofac
 {
     [TestWithNuGetPackage(Packages = new[] { "Autofac/3.5.2" })]
     public class RegisterAssemblyTypesTests : AgentMulderTestBase<AutofacContainerInfo>
     {
-        protected override string RelativeTestDataPath
+        private const string RelativePath = @"Autofac\RegisterAssemblyTypesTests";
+
+        protected override string RelativeTestDataPath => RelativePath;
+
+        [Test]
+        [TestCaseSource(nameof(TestCases), methodParams: new object[] { RelativePath })]
+        public void Test(string fileName)
         {
-            get { return @"Autofac\RegisterAssemblyTypesTests"; }
+            TestCore(fileName);
+        }
+
+        private static IEnumerable TestCases(string relativePath)
+        {
+            TestUtil.SetHomeDir(typeof(AgentMulderTestBase<>).Assembly);
+            var d = new DirectoryInfo(Path.Combine(
+                TestUtil.GetTestDataPathBase(typeof(AgentMulderTestBase<>).Assembly).FullPath, relativePath));
+
+            var testCaseData = d.EnumerateFiles("*.cs")
+                .Select(info => new TestCaseData(info.Name))
+                .ToList();
+
+            return testCaseData;
         }
     }
 }

--- a/src/AgentMulder.ReSharper.Tests/Catel/ServiceLocatorTests.cs
+++ b/src/AgentMulder.ReSharper.Tests/Catel/ServiceLocatorTests.cs
@@ -1,13 +1,37 @@
-﻿using AgentMulder.Containers.Catel;
+﻿using System.Collections;
+using System.IO;
+using System.Linq;
+using AgentMulder.Containers.Catel;
+using JetBrains.TestFramework.Utils;
+using NUnit.Framework;
 
 namespace AgentMulder.ReSharper.Tests.Catel
 {
     [TestWithNuGetPackage(Packages = new[] { "Catel.Core/3.9.0" })]
     public class ServiceLocatorTests : AgentMulderTestBase<CatelContainerInfo>
     {
-        protected override string RelativeTestDataPath
+        private const string RelativePath = "Catel";
+
+        protected override string RelativeTestDataPath => RelativePath;
+
+        [Test]
+        [TestCaseSource(nameof(TestCases), methodParams: new object[] { RelativePath })]
+        public void Test(string fileName)
         {
-            get { return @"Catel"; }
+            TestCore(fileName);
+        }
+
+        private static IEnumerable TestCases(string relativePath)
+        {
+            TestUtil.SetHomeDir(typeof(AgentMulderTestBase<>).Assembly);
+            var d = new DirectoryInfo(Path.Combine(
+                TestUtil.GetTestDataPathBase(typeof(AgentMulderTestBase<>).Assembly).FullPath, relativePath));
+
+            var testCaseData = d.EnumerateFiles("*.cs")
+                .Select(info => new TestCaseData(info.Name))
+                .ToList();
+
+            return testCaseData;
         }
     }
 }

--- a/src/AgentMulder.ReSharper.Tests/LightInject/ContainerTests.cs
+++ b/src/AgentMulder.ReSharper.Tests/LightInject/ContainerTests.cs
@@ -1,10 +1,37 @@
-﻿using AgentMulder.Containers.LightInject;
+﻿using System.Collections;
+using System.IO;
+using System.Linq;
+using AgentMulder.Containers.LightInject;
+using JetBrains.TestFramework.Utils;
+using NUnit.Framework;
 
 namespace AgentMulder.ReSharper.Tests.LightInject
 {
     [TestWithNuGetPackage(Packages = new[] { "LightInject" })]
     public class ContainerTests : AgentMulderTestBase<LightInjectContainerInfo>
     {
-        protected override string RelativeTestDataPath => "LightInject";
+        private const string RelativePath = "LightInject";
+
+        protected override string RelativeTestDataPath => RelativePath;
+
+        [Test]
+        [TestCaseSource(nameof(TestCases), methodParams: new object[] { RelativePath })]
+        public void Test(string fileName)
+        {
+            TestCore(fileName);
+        }
+
+        private static IEnumerable TestCases(string relativePath)
+        {
+            TestUtil.SetHomeDir(typeof(AgentMulderTestBase<>).Assembly);
+            var d = new DirectoryInfo(Path.Combine(
+                TestUtil.GetTestDataPathBase(typeof(AgentMulderTestBase<>).Assembly).FullPath, relativePath));
+
+            var testCaseData = d.EnumerateFiles("*.cs")
+                .Select(info => new TestCaseData(info.Name))
+                .ToList();
+
+            return testCaseData;
+        }
     }
 }

--- a/src/AgentMulder.ReSharper.Tests/Ninject/KernelTests.cs
+++ b/src/AgentMulder.ReSharper.Tests/Ninject/KernelTests.cs
@@ -1,13 +1,37 @@
+using System.Collections;
+using System.IO;
+using System.Linq;
 using AgentMulder.Containers.Ninject;
+using JetBrains.TestFramework.Utils;
+using NUnit.Framework;
 
 namespace AgentMulder.ReSharper.Tests.Ninject
 {
     [TestWithNuGetPackage(Packages = new[] { "Ninject/3.2.2.0" })]
     public class KernelTests : AgentMulderTestBase<NinjectContainerInfo>
     {
-        protected override string RelativeTestDataPath
+        private const string RelativePath = @"Ninject\KernelTestCases";
+
+        protected override string RelativeTestDataPath => RelativePath;
+
+        [Test]
+        [TestCaseSource(nameof(TestCases), methodParams: new object[] { RelativePath })]
+        public void Test(string fileName)
         {
-            get { return @"Ninject\KernelTestCases"; }
+            TestCore(fileName);
+        }
+
+        private static IEnumerable TestCases(string relativePath)
+        {
+            TestUtil.SetHomeDir(typeof(AgentMulderTestBase<>).Assembly);
+            var d = new DirectoryInfo(Path.Combine(
+                TestUtil.GetTestDataPathBase(typeof(AgentMulderTestBase<>).Assembly).FullPath, relativePath));
+
+            var testCaseData = d.EnumerateFiles("*.cs")
+                .Select(info => new TestCaseData(info.Name))
+                .ToList();
+
+            return testCaseData;
         }
     }
 }

--- a/src/AgentMulder.ReSharper.Tests/Ninject/ModuleTests.cs
+++ b/src/AgentMulder.ReSharper.Tests/Ninject/ModuleTests.cs
@@ -1,13 +1,37 @@
+using System.Collections;
+using System.IO;
+using System.Linq;
 using AgentMulder.Containers.Ninject;
+using JetBrains.TestFramework.Utils;
+using NUnit.Framework;
 
 namespace AgentMulder.ReSharper.Tests.Ninject
 {
     [TestWithNuGetPackage(Packages = new[] { "Ninject/3.2.2.0" })]
     public class ModuleTests : AgentMulderTestBase<NinjectContainerInfo>
     {
-        protected override string RelativeTestDataPath
+        private const string RelativePath = @"Ninject\ModuleTestCases";
+
+        protected override string RelativeTestDataPath => RelativePath;
+
+        [Test]
+        [TestCaseSource(nameof(TestCases), methodParams: new object[] { RelativePath })]
+        public void Test(string fileName)
         {
-            get { return @"Ninject\ModuleTestCases"; }
+            TestCore(fileName);
+        }
+
+        private static IEnumerable TestCases(string relativePath)
+        {
+            TestUtil.SetHomeDir(typeof(AgentMulderTestBase<>).Assembly);
+            var d = new DirectoryInfo(Path.Combine(
+                TestUtil.GetTestDataPathBase(typeof(AgentMulderTestBase<>).Assembly).FullPath, relativePath));
+
+            var testCaseData = d.EnumerateFiles("*.cs")
+                .Select(info => new TestCaseData(info.Name))
+                .ToList();
+
+            return testCaseData;
         }
     }
 }

--- a/src/AgentMulder.ReSharper.Tests/Ninject/SanityTests.cs
+++ b/src/AgentMulder.ReSharper.Tests/Ninject/SanityTests.cs
@@ -1,13 +1,37 @@
-﻿using AgentMulder.Containers.Ninject;
+﻿using System.Collections;
+using System.IO;
+using System.Linq;
+using AgentMulder.Containers.Ninject;
+using JetBrains.TestFramework.Utils;
+using NUnit.Framework;
 
 namespace AgentMulder.ReSharper.Tests.Ninject
 {
     [TestWithNuGetPackage(Packages = new[] { "Ninject/3.2.2.0" })]
     public class SanityTests : AgentMulderTestBase<NinjectContainerInfo>
     {
-        protected override string RelativeTestDataPath
+        private const string RelativePath = "Ninject";
+
+        protected override string RelativeTestDataPath => RelativePath;
+
+        [Test]
+        [TestCaseSource(nameof(TestCases), methodParams: new object[] { RelativePath })]
+        public void Test(string fileName)
         {
-            get { return @"Ninject"; }
+            TestCore(fileName);
+        }
+
+        private static IEnumerable TestCases(string relativePath)
+        {
+            TestUtil.SetHomeDir(typeof(AgentMulderTestBase<>).Assembly);
+            var d = new DirectoryInfo(Path.Combine(
+                TestUtil.GetTestDataPathBase(typeof(AgentMulderTestBase<>).Assembly).FullPath, relativePath));
+
+            var testCaseData = d.EnumerateFiles("*.cs")
+                .Select(info => new TestCaseData(info.Name))
+                .ToList();
+
+            return testCaseData;
         }
     }
 }

--- a/src/AgentMulder.ReSharper.Tests/ReSharperTestEnvironmentAssembly.cs
+++ b/src/AgentMulder.ReSharper.Tests/ReSharperTestEnvironmentAssembly.cs
@@ -1,11 +1,12 @@
-﻿﻿using JetBrains.Application.BuildScript.Application.Zones;
+﻿﻿using System.Threading;
+ using JetBrains.Application.BuildScript.Application.Zones;
 ﻿using JetBrains.ReSharper.TestFramework;
 ﻿using JetBrains.TestFramework;
 ﻿using JetBrains.TestFramework.Application.Zones;
 ﻿using NUnit.Framework;
 
 
-[assembly: RequiresSTA]
+[assembly: Apartment(ApartmentState.STA)]
 
 /// <summary>
 /// Test environment. Must be in the global namespace.

--- a/src/AgentMulder.ReSharper.Tests/SimpleInjector/ContainerTests.cs
+++ b/src/AgentMulder.ReSharper.Tests/SimpleInjector/ContainerTests.cs
@@ -1,13 +1,37 @@
-﻿using AgentMulder.Containers.SimpleInjector;
+﻿using System.Collections;
+using System.IO;
+using System.Linq;
+using AgentMulder.Containers.SimpleInjector;
+using JetBrains.TestFramework.Utils;
+using NUnit.Framework;
 
 namespace AgentMulder.ReSharper.Tests.SimpleInjector
 {
     [TestWithNuGetPackage(Packages = new[] { "SimpleInjector/2.5.2" })]
     public class ContainerTests : AgentMulderTestBase<SimpleInjectorContainerInfo>
     {
-        protected override string RelativeTestDataPath
+        private const string RelativePath = "SimpleInjector";
+
+        protected override string RelativeTestDataPath => RelativePath;
+
+        [Test]
+        [TestCaseSource(nameof(TestCases), methodParams: new object[] { RelativePath })]
+        public void Test(string fileName)
         {
-            get { return @"SimpleInjector"; }
+            TestCore(fileName);
+        }
+
+        private static IEnumerable TestCases(string relativePath)
+        {
+            TestUtil.SetHomeDir(typeof(AgentMulderTestBase<>).Assembly);
+            var d = new DirectoryInfo(Path.Combine(
+                TestUtil.GetTestDataPathBase(typeof(AgentMulderTestBase<>).Assembly).FullPath, relativePath));
+
+            var testCaseData = d.EnumerateFiles("*.cs")
+                .Select(info => new TestCaseData(info.Name))
+                .ToList();
+
+            return testCaseData;
         }
     }
 }

--- a/src/AgentMulder.ReSharper.Tests/StructureMap/ContainerTests.cs
+++ b/src/AgentMulder.ReSharper.Tests/StructureMap/ContainerTests.cs
@@ -1,13 +1,37 @@
-﻿using AgentMulder.Containers.StructureMap;
+﻿using System.Collections;
+using System.IO;
+using System.Linq;
+using AgentMulder.Containers.StructureMap;
+using JetBrains.TestFramework.Utils;
+using NUnit.Framework;
 
 namespace AgentMulder.ReSharper.Tests.StructureMap
 {
     [TestWithNuGetPackage(Packages = new[] { "StructureMap/3.1.1.134" })]
     public class ContainerTests : AgentMulderTestBase<StructureMapContainerInfo>
     {
-        protected override string RelativeTestDataPath
+        private const string RelativePath = @"StructureMap\ContainerTests";
+
+        protected override string RelativeTestDataPath => RelativePath;
+
+        [Test]
+        [TestCaseSource(nameof(TestCases), methodParams: new object[] { RelativePath })]
+        public void Test(string fileName)
         {
-            get { return @"StructureMap\ContainerTests"; }
+            TestCore(fileName);
+        }
+
+        private static IEnumerable TestCases(string relativePath)
+        {
+            TestUtil.SetHomeDir(typeof(AgentMulderTestBase<>).Assembly);
+            var d = new DirectoryInfo(Path.Combine(
+                TestUtil.GetTestDataPathBase(typeof(AgentMulderTestBase<>).Assembly).FullPath, relativePath));
+
+            var testCaseData = d.EnumerateFiles("*.cs")
+                .Select(info => new TestCaseData(info.Name))
+                .ToList();
+
+            return testCaseData;
         }
     }
 }

--- a/src/AgentMulder.ReSharper.Tests/StructureMap/SanityTests.cs
+++ b/src/AgentMulder.ReSharper.Tests/StructureMap/SanityTests.cs
@@ -1,13 +1,37 @@
-﻿using AgentMulder.Containers.StructureMap;
+﻿using System.Collections;
+using System.IO;
+using System.Linq;
+using AgentMulder.Containers.StructureMap;
+using JetBrains.TestFramework.Utils;
+using NUnit.Framework;
 
 namespace AgentMulder.ReSharper.Tests.StructureMap
 {
     [TestWithNuGetPackage(Packages = new[] { "StructureMap/3.1.1.134" })]
     public class SanityTests : AgentMulderTestBase<StructureMapContainerInfo>
     {
-        protected override string RelativeTestDataPath
+        private const string RelativePath = "StructureMap";
+
+        protected override string RelativeTestDataPath => RelativePath;
+
+        [Test]
+        [TestCaseSource(nameof(TestCases), methodParams: new object[] { RelativePath })]
+        public void Test(string fileName)
         {
-            get { return @"StructureMap"; }
+            TestCore(fileName);
+        }
+
+        private static IEnumerable TestCases(string relativePath)
+        {
+            TestUtil.SetHomeDir(typeof(AgentMulderTestBase<>).Assembly);
+            var d = new DirectoryInfo(Path.Combine(
+                TestUtil.GetTestDataPathBase(typeof(AgentMulderTestBase<>).Assembly).FullPath, relativePath));
+
+            var testCaseData = d.EnumerateFiles("*.cs")
+                .Select(info => new TestCaseData(info.Name))
+                .ToList();
+
+            return testCaseData;
         }
     }
 }

--- a/src/AgentMulder.ReSharper.Tests/StructureMap/ScanTests.cs
+++ b/src/AgentMulder.ReSharper.Tests/StructureMap/ScanTests.cs
@@ -1,13 +1,37 @@
-﻿using AgentMulder.Containers.StructureMap;
+﻿using System.Collections;
+using System.IO;
+using System.Linq;
+using AgentMulder.Containers.StructureMap;
+using JetBrains.TestFramework.Utils;
+using NUnit.Framework;
 
 namespace AgentMulder.ReSharper.Tests.StructureMap
 {
     [TestWithNuGetPackage(Packages = new[] { "StructureMap/3.1.1.134" })]
     public class ScanTests : AgentMulderTestBase<StructureMapContainerInfo>
     {
-        protected override string RelativeTestDataPath
+        private const string RelativePath = @"StructureMap\ScanTests";
+
+        protected override string RelativeTestDataPath => RelativePath;
+
+        [Test]
+        [TestCaseSource(nameof(TestCases), methodParams: new object[] { RelativePath })]
+        public void Test(string fileName)
         {
-            get { return @"StructureMap\ScanTests"; }
+            TestCore(fileName);
+        }
+
+        private static IEnumerable TestCases(string relativePath)
+        {
+            TestUtil.SetHomeDir(typeof(AgentMulderTestBase<>).Assembly);
+            var d = new DirectoryInfo(Path.Combine(
+                TestUtil.GetTestDataPathBase(typeof(AgentMulderTestBase<>).Assembly).FullPath, relativePath));
+
+            var testCaseData = d.EnumerateFiles("*.cs")
+                .Select(info => new TestCaseData(info.Name))
+                .ToList();
+
+            return testCaseData;
         }
     }
 }

--- a/src/AgentMulder.ReSharper.Tests/Unity/RegisterTypeTests.cs
+++ b/src/AgentMulder.ReSharper.Tests/Unity/RegisterTypeTests.cs
@@ -1,13 +1,37 @@
-﻿using AgentMulder.Containers.Unity;
+﻿using System.Collections;
+using System.IO;
+using System.Linq;
+using AgentMulder.Containers.Unity;
+using JetBrains.TestFramework.Utils;
+using NUnit.Framework;
 
 namespace AgentMulder.ReSharper.Tests.Unity
 {
     [TestWithNuGetPackage(Packages = new[] { "Unity/3.5.1404", "CommonServiceLocator/1.2.0" })]
     public class RegisterTypeTests : AgentMulderTestBase<UnityContainerInfo>
     {
-        protected override string RelativeTestDataPath
+        private const string RelativePath = "Unity";
+
+        protected override string RelativeTestDataPath => RelativePath;
+
+        [Test]
+        [TestCaseSource(nameof(TestCases), methodParams: new object[] { RelativePath })]
+        public void Test(string fileName)
         {
-            get { return @"Unity"; }
+            TestCore(fileName);
+        }
+
+        private static IEnumerable TestCases(string relativePath)
+        {
+            TestUtil.SetHomeDir(typeof(AgentMulderTestBase<>).Assembly);
+            var d = new DirectoryInfo(Path.Combine(
+                TestUtil.GetTestDataPathBase(typeof(AgentMulderTestBase<>).Assembly).FullPath, relativePath));
+
+            var testCaseData = d.EnumerateFiles("*.cs")
+                .Select(info => new TestCaseData(info.Name))
+                .ToList();
+
+            return testCaseData;
         }
     }
 }

--- a/src/AgentMulder.ReSharper.Tests/Windsor/AllTypesTests.cs
+++ b/src/AgentMulder.ReSharper.Tests/Windsor/AllTypesTests.cs
@@ -1,16 +1,20 @@
+using System.Collections;
+using System.IO;
+using System.Linq;
 using AgentMulder.Containers.CastleWindsor;
 using AgentMulder.Containers.CastleWindsor.Providers;
 using AgentMulder.ReSharper.Domain.Containers;
+using JetBrains.TestFramework.Utils;
+using NUnit.Framework;
 
 namespace AgentMulder.ReSharper.Tests.Windsor
 {
     [TestWithNuGetPackage(Packages = new[] { "Castle.Windsor/3.3.0", "Castle.Core/3.3.0" })]
     public class AllTypesTests : AgentMulderTestBase<WindsorContainerInfo>
     {
-        protected override string RelativeTestDataPath
-        {
-            get { return @"Windsor\TestCases"; }
-        }
+        private const string RelativePath = @"Windsor\TestCases";
+
+        protected override string RelativeTestDataPath => RelativePath;
 
         protected override IContainerInfo ContainerInfo
         {
@@ -21,6 +25,26 @@ namespace AgentMulder.ReSharper.Tests.Windsor
                     new AllTypesRegistrationProvider(new BasedOnRegistrationProvider())
                 });
             }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(TestCases), methodParams: new object[] { RelativePath })]
+        public void Test(string fileName)
+        {
+            TestCore(fileName);
+        }
+
+        private static IEnumerable TestCases(string relativePath)
+        {
+            TestUtil.SetHomeDir(typeof(AgentMulderTestBase<>).Assembly);
+            var d = new DirectoryInfo(Path.Combine(
+                TestUtil.GetTestDataPathBase(typeof(AgentMulderTestBase<>).Assembly).FullPath, relativePath));
+
+            var testCaseData = d.EnumerateFiles("*.cs")
+                .Select(info => new TestCaseData(info.Name))
+                .ToList();
+
+            return testCaseData;
         }
     }
 }

--- a/src/AgentMulder.ReSharper.Tests/Windsor/ClassesTests.cs
+++ b/src/AgentMulder.ReSharper.Tests/Windsor/ClassesTests.cs
@@ -1,16 +1,20 @@
+using System.Collections;
+using System.IO;
+using System.Linq;
 using AgentMulder.Containers.CastleWindsor;
 using AgentMulder.Containers.CastleWindsor.Providers;
 using AgentMulder.ReSharper.Domain.Containers;
+using JetBrains.TestFramework.Utils;
+using NUnit.Framework;
 
 namespace AgentMulder.ReSharper.Tests.Windsor
 {
     [TestWithNuGetPackage(Packages = new[] { "Castle.Windsor/3.3.0", "Castle.Core/3.3.0" })]
     public class ClassesTests : AgentMulderTestBase<WindsorContainerInfo>
     {
-        protected override string RelativeTestDataPath
-        {
-            get { return @"Windsor\TestCases"; }
-        }
+        private const string RelativePath = @"Windsor\TestCases";
+
+        protected override string RelativeTestDataPath => RelativePath;
 
         protected override IContainerInfo ContainerInfo
         {
@@ -21,6 +25,26 @@ namespace AgentMulder.ReSharper.Tests.Windsor
                     new ClassesRegistrationProvider(new BasedOnRegistrationProvider())
                 });
             }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(TestCases), methodParams: new object[] { RelativePath })]
+        public void Test(string fileName)
+        {
+            TestCore(fileName);
+        }
+
+        private static IEnumerable TestCases(string relativePath)
+        {
+            TestUtil.SetHomeDir(typeof(AgentMulderTestBase<>).Assembly);
+            var d = new DirectoryInfo(Path.Combine(
+                TestUtil.GetTestDataPathBase(typeof(AgentMulderTestBase<>).Assembly).FullPath, relativePath));
+
+            var testCaseData = d.EnumerateFiles("*.cs")
+                .Select(info => new TestCaseData(info.Name))
+                .ToList();
+
+            return testCaseData;
         }
     }
 }

--- a/src/AgentMulder.ReSharper.Tests/Windsor/ComponentRegistrationTests.cs
+++ b/src/AgentMulder.ReSharper.Tests/Windsor/ComponentRegistrationTests.cs
@@ -1,17 +1,21 @@
 ﻿using System;
+using System.Collections;
+using System.IO;
+using System.Linq;
 using AgentMulder.Containers.CastleWindsor;
 using AgentMulder.Containers.CastleWindsor.Providers;
 using AgentMulder.ReSharper.Domain.Containers;
+using JetBrains.TestFramework.Utils;
+using NUnit.Framework;
 
 namespace AgentMulder.ReSharper.Tests.Windsor
 {
     [TestWithNuGetPackage(Packages = new[] { "Castle.Windsor/3.3.0", "Castle.Core/3.3.0" })]
     public class ComponentRegistrationTests : AgentMulderTestBase<WindsorContainerInfo>
     {
-        protected override string RelativeTestDataPath
-        {
-            get { return @"Windsor\ComponentTestCases"; }
-        }
+        private const string RelativePath = @"Windsor\ComponentTestCases";
+
+        protected override string RelativeTestDataPath => RelativePath;
 
         protected override IContainerInfo ContainerInfo
         {
@@ -22,6 +26,26 @@ namespace AgentMulder.ReSharper.Tests.Windsor
                     new ComponentRegistrationProvider(new ImplementedByRegistrationProvider())
                 });
             }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(TestCases), methodParams: new object[] { RelativePath })]
+        public void Test(string fileName)
+        {
+            TestCore(fileName);
+        }
+
+        private static IEnumerable TestCases(string relativePath)
+        {
+            TestUtil.SetHomeDir(typeof(AgentMulderTestBase<>).Assembly);
+            var d = new DirectoryInfo(Path.Combine(
+                TestUtil.GetTestDataPathBase(typeof(AgentMulderTestBase<>).Assembly).FullPath, relativePath));
+
+            var testCaseData = d.EnumerateFiles("*.cs")
+                .Select(info => new TestCaseData(info.Name))
+                .ToList();
+
+            return testCaseData;
         }
     }
 }

--- a/src/AgentMulder.ReSharper.Tests/Windsor/SanityTests.cs
+++ b/src/AgentMulder.ReSharper.Tests/Windsor/SanityTests.cs
@@ -1,16 +1,20 @@
-﻿using AgentMulder.Containers.CastleWindsor;
+﻿using System.Collections;
+using System.IO;
+using System.Linq;
+using AgentMulder.Containers.CastleWindsor;
 using AgentMulder.Containers.CastleWindsor.Providers;
 using AgentMulder.ReSharper.Domain.Containers;
+using JetBrains.TestFramework.Utils;
+using NUnit.Framework;
 
 namespace AgentMulder.ReSharper.Tests.Windsor
 {
     [TestWithNuGetPackage(Packages = new[] { "Castle.Windsor/3.3.0", "Castle.Core/3.3.0" })]
     public class SanityTests : AgentMulderTestBase<WindsorContainerInfo>
     {
-        protected override string RelativeTestDataPath
-        {
-            get { return @"Windsor"; }
-        }
+        private const string RelativePath = "Windsor";
+
+        protected override string RelativeTestDataPath => RelativePath;
 
         protected override IContainerInfo ContainerInfo
         {
@@ -21,6 +25,26 @@ namespace AgentMulder.ReSharper.Tests.Windsor
                     new ClassesRegistrationProvider(new BasedOnRegistrationProvider())
                 });
             }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(TestCases), methodParams: new object[] { RelativePath })]
+        public void Test(string fileName)
+        {
+            TestCore(fileName);
+        }
+
+        private static IEnumerable TestCases(string relativePath)
+        {
+            TestUtil.SetHomeDir(typeof(AgentMulderTestBase<>).Assembly);
+            var d = new DirectoryInfo(Path.Combine(
+                TestUtil.GetTestDataPathBase(typeof(AgentMulderTestBase<>).Assembly).FullPath, relativePath));
+
+            var testCaseData = d.EnumerateFiles("*.cs")
+                .Select(info => new TestCaseData(info.Name))
+                .ToList();
+
+            return testCaseData;
         }
     }
 }

--- a/src/AgentMulder.ReSharper.Tests/Windsor/TypesTests.cs
+++ b/src/AgentMulder.ReSharper.Tests/Windsor/TypesTests.cs
@@ -1,16 +1,20 @@
+using System.Collections;
+using System.IO;
+using System.Linq;
 using AgentMulder.Containers.CastleWindsor;
 using AgentMulder.Containers.CastleWindsor.Providers;
 using AgentMulder.ReSharper.Domain.Containers;
+using JetBrains.TestFramework.Utils;
+using NUnit.Framework;
 
 namespace AgentMulder.ReSharper.Tests.Windsor
 {
     [TestWithNuGetPackage(Packages = new[] { "Castle.Windsor/3.3.0", "Castle.Core/3.3.0" })]
     public class TypesTests : AgentMulderTestBase<WindsorContainerInfo>
     {
-        protected override string RelativeTestDataPath
-        {
-            get { return @"Windsor\TestCases"; }
-        }
+        private const string RelativePath = @"Windsor\TestCases";
+
+        protected override string RelativeTestDataPath => RelativePath;
 
         protected override IContainerInfo ContainerInfo
         {
@@ -21,6 +25,26 @@ namespace AgentMulder.ReSharper.Tests.Windsor
                     new TypesRegistrationProvider(new BasedOnRegistrationProvider())
                 });
             }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(TestCases), methodParams: new object[] { RelativePath })]
+        public void Test(string fileName)
+        {
+            TestCore(fileName);
+        }
+
+        private static IEnumerable TestCases(string relativePath)
+        {
+            TestUtil.SetHomeDir(typeof(AgentMulderTestBase<>).Assembly);
+            var d = new DirectoryInfo(Path.Combine(
+                TestUtil.GetTestDataPathBase(typeof(AgentMulderTestBase<>).Assembly).FullPath, relativePath));
+
+            var testCaseData = d.EnumerateFiles("*.cs")
+                .Select(info => new TestCaseData(info.Name))
+                .ToList();
+
+            return testCaseData;
         }
     }
 }

--- a/src/Test/Data/TestApplication.csproj
+++ b/src/Test/Data/TestApplication.csproj
@@ -168,9 +168,8 @@
       <HintPath>..\..\packages\System.AppContext.4.3.0\lib\net46\System.AppContext.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Collections.Immutable, Version=1.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Collections.Immutable.1.3.0\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Collections.Immutable, Version=1.2.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Collections.Immutable.1.5.0\lib\netstandard1.3\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/src/Test/Data/app.config
+++ b/src/Test/Data/app.config
@@ -27,6 +27,10 @@
         <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.3.0" newVersion="1.2.3.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/src/Test/Data/packages.config
+++ b/src/Test/Data/packages.config
@@ -34,7 +34,7 @@
   <package id="System.AppContext" version="4.3.0" targetFramework="net46" />
   <package id="System.Collections" version="4.3.0" targetFramework="net46" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net46" />
-  <package id="System.Collections.Immutable" version="1.3.0" targetFramework="net46" />
+  <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net46" />
   <package id="System.ComponentModel" version="4.3.0" targetFramework="net46" />
   <package id="System.Console" version="4.3.0" targetFramework="net46" />
   <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net46" />


### PR DESCRIPTION
Adds support for R# 2019.2. Some necessary test framework refactoring (R# moved to NUnit 3.x which cased some breaking changes).